### PR TITLE
Improvements for Piano View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ shared
 .externalNativeBuild
 .gradle
 keystore.properties
+.idea
+local.properties
+*.iml

--- a/README
+++ b/README
@@ -45,3 +45,9 @@ This software uses:
    the Apache 2.0
 
  * audio provided by the University of Iowa Musical Instrument Samples project
+
+-------
+
+Contributors:
+
+    Sascha Lüdecke <sascha@meta-x.de>

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 2
-        versionName "1.1"
+        versionName "1.2-dev"
         externalNativeBuild {
             cmake {
                 arguments "-DANDROID_PLATFORM=android-16"

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="mn.tck.semitone">
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-sdk android:minSdkVersion="16"
-              android:targetSdkVersion="28" />
     <application android:label="@string/app_name"
                  android:icon="@mipmap/ic_launcher"
                  android:theme="@style/SemitoneTheme"

--- a/src/main/java/mn.tck.semitone/MainActivity.java
+++ b/src/main/java/mn.tck.semitone/MainActivity.java
@@ -55,13 +55,6 @@ public class MainActivity extends FragmentActivity {
         PianoEngine.create(this);
         RecordEngine.create(this);
 
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
-        SharedPreferences.Editor e = sp.edit();
-        if (!sp.contains("concert_a")) e.putString("concert_a", "440");
-        if (!sp.contains("sustain")) e.putBoolean("sustain", false);
-        if (!sp.contains("labelnotes")) e.putBoolean("labelnotes", false);
-        e.commit();
-
         tt = getResources().getString(R.string.tuner_title);
         mt = getResources().getString(R.string.metronome_title);
         pt = getResources().getString(R.string.piano_title);
@@ -83,7 +76,7 @@ public class MainActivity extends FragmentActivity {
         });
 
         // fullscreen = (ImageView) findViewById(R.id.fullscreen);
-        settings = (ImageView) findViewById(R.id.settings);
+        settings = findViewById(R.id.settings);
 
         settings.setOnClickListener(new View.OnClickListener() {
             @Override public void onClick(View v) {

--- a/src/main/java/mn.tck.semitone/PianoFragment.java
+++ b/src/main/java/mn.tck.semitone/PianoFragment.java
@@ -27,6 +27,15 @@ import android.support.v7.preference.PreferenceManager;
 
 public class PianoFragment extends SemitoneFragment {
 
+    private static final String PREF_SUSTAIN = "sustain";
+    private static final String PREF_LABELNOTES = "labelnotes";
+    private static final String PREF_LABELNOTESLIGHT = "labelnoteslight";
+    private static final String PREF_CONCERT_A = "concert_a";
+    private static final boolean PREF_SUSTAIN_DEFAULT = false;
+    private static final boolean PREF_LABELNOTESLIGHT_DEFAULT = false;
+    private static final boolean PREF_LABELNOTES_DEFAULT = false;
+    private static final String PREF_CONCERT_A_DEFAULT = "440";
+
     PianoView piano;
     View view;
 
@@ -105,12 +114,13 @@ public class PianoFragment extends SemitoneFragment {
     @Override public void onSettingsChanged() {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getContext());
         try {
-            piano.concert_a = Integer.parseInt(sp.getString("concert_a", "440"));
+            piano.concert_a = Integer.parseInt(sp.getString(PREF_CONCERT_A, PREF_CONCERT_A_DEFAULT));
         } catch (NumberFormatException e) {
             piano.concert_a = 440;
         }
-        piano.sustain = sp.getBoolean("sustain", false);
-        piano.labelnotes = sp.getBoolean("labelnotes", false);
+        piano.sustain = sp.getBoolean(PREF_SUSTAIN, PREF_SUSTAIN_DEFAULT);
+        piano.labelnotes = sp.getBoolean(PREF_LABELNOTES, PREF_LABELNOTES_DEFAULT);
+        piano.labelnoteslight = sp.getBoolean(PREF_LABELNOTESLIGHT, PREF_LABELNOTESLIGHT_DEFAULT);
     }
 
 }

--- a/src/main/java/mn.tck.semitone/PianoFragment.java
+++ b/src/main/java/mn.tck.semitone/PianoFragment.java
@@ -19,22 +19,27 @@
 package mn.tck.semitone;
 
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.support.v7.preference.PreferenceManager;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
 
 public class PianoFragment extends SemitoneFragment {
 
-    private static final String PREF_SUSTAIN = "sustain";
-    private static final String PREF_LABELNOTES = "labelnotes";
-    private static final String PREF_LABELNOTESLIGHT = "labelnoteslight";
-    private static final String PREF_CONCERT_A = "concert_a";
-    private static final boolean PREF_SUSTAIN_DEFAULT = false;
-    private static final boolean PREF_LABELNOTESLIGHT_DEFAULT = false;
-    private static final boolean PREF_LABELNOTES_DEFAULT = false;
-    private static final String PREF_CONCERT_A_DEFAULT = "440";
+    static final String PREF_SUSTAIN = "sustain";
+    static final String PREF_LABELNOTES = "labelnotes";
+    static final String PREF_LABELNOTESLIGHT = "labelnoteslight";
+    static final String PREF_CONCERT_A = "concert_a";
+
+    static final boolean PREF_SUSTAIN_DEFAULT = false;
+    static final boolean PREF_LABELNOTESLIGHT_DEFAULT = false;
+    static final boolean PREF_LABELNOTES_DEFAULT = false;
+    static final String PREF_CONCERT_A_DEFAULT = "440";
 
     PianoView piano;
     View view;
@@ -102,12 +107,53 @@ public class PianoFragment extends SemitoneFragment {
                 piano.updateParams(true);
             }
         });
-        view.findViewById(R.id.reset_view).setOnClickListener(new View.OnClickListener() {
-            @Override public void onClick(View v) {
-                piano.setDefaults();
+
+
+        // Setup the root note spinner
+        final Spinner rootNoteSpinner = view.findViewById(R.id.root_note_spinner);
+        final ArrayAdapter<CharSequence> rootNoteAdapter = ArrayAdapter.createFromResource(getContext(),
+                R.array.noteNames, android.R.layout.simple_spinner_item);
+        rootNoteAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        rootNoteSpinner.setAdapter(rootNoteAdapter);
+        rootNoteSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                piano.setScale(piano.scale, i);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+                // NOP
             }
         });
 
+        // Setup the scale spinner
+        final Spinner scaleSpinner = view.findViewById(R.id.scale_spinner);
+        ArrayAdapter<CharSequence> scaleAdapter = ArrayAdapter.createFromResource(getContext(),
+                getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE ? R.array.scaleNamesShort : R.array.scaleNames,
+                android.R.layout.simple_spinner_item);
+        scaleAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        scaleSpinner.setAdapter(scaleAdapter);
+        scaleSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                piano.setScale(i, piano.rootNote);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+                // NOP
+            }
+        });
+
+
+        view.findViewById(R.id.reset_view).setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                scaleSpinner.setSelection(PianoView.PREF_SCALE_DEFAULT);
+                rootNoteSpinner.setSelection(PianoView.PREF_SCALE_ROOT_DEFAULT);
+                piano.setDefaults();
+            }
+        });
         onSettingsChanged();
     }
 

--- a/src/main/java/mn.tck.semitone/PianoFragment.java
+++ b/src/main/java/mn.tck.semitone/PianoFragment.java
@@ -93,6 +93,11 @@ public class PianoFragment extends SemitoneFragment {
                 piano.updateParams(true);
             }
         });
+        view.findViewById(R.id.reset_view).setOnClickListener(new View.OnClickListener() {
+            @Override public void onClick(View v) {
+                piano.setDefaults();
+            }
+        });
 
         onSettingsChanged();
     }

--- a/src/main/java/mn.tck.semitone/PianoView.java
+++ b/src/main/java/mn.tck.semitone/PianoView.java
@@ -19,8 +19,10 @@
 package mn.tck.semitone;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.support.v7.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -29,6 +31,15 @@ import android.support.v4.content.ContextCompat;
 import java.util.HashMap;
 
 public class PianoView extends View {
+
+    private final static String PREF_ROWS = "rows";
+    private final static String PREF_KEYS = "keys";
+    private final static String PREF_PITCH = "pitch";
+
+    private final static int PREF_ROWS_DEFAULT = 2;
+    private final static int PREF_KEYS_DEFAULT = 7;
+    private final static int PREF_PITCH_DEFAULT = 28;
+
 
     public int rows, keys, pitch;
     int whiteWidth, whiteHeight, blackWidth, blackHeight;
@@ -48,9 +59,12 @@ public class PianoView extends View {
     public PianoView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        rows = 2;
-        keys = 7;
-        pitch = 28;
+        // get parameters from preferences (or use default values)
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        rows = sp.getInt(PREF_ROWS, PREF_ROWS_DEFAULT);
+        keys = sp.getInt(PREF_KEYS, PREF_KEYS_DEFAULT);
+        pitch = sp.getInt(PREF_PITCH, PREF_PITCH_DEFAULT);
+
         updateParams(false);
 
         whitePaint = new Paint();
@@ -69,6 +83,14 @@ public class PianoView extends View {
         pointers = new HashMap<Integer, Integer>();
     }
 
+    public void setDefaults() {
+        rows = PREF_ROWS_DEFAULT;
+        keys = PREF_KEYS_DEFAULT;
+        pitch = PREF_PITCH_DEFAULT;
+
+        updateParams(true);
+    }
+
     public void updateParams(boolean inval) {
         pitches = new int[rows][keys];
 
@@ -81,7 +103,17 @@ public class PianoView extends View {
             }
         }
 
-        if (inval) invalidate();
+
+        if (inval) {
+            // store parameters in preferences
+            SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getContext()).edit();
+            editor.putInt(PREF_ROWS, rows);
+            editor.putInt(PREF_KEYS, keys);
+            editor.putInt(PREF_PITCH, pitch);
+            editor.apply();
+
+            invalidate();
+        }
     }
 
     @Override protected void onDraw(Canvas canvas) {

--- a/src/main/java/mn.tck.semitone/PianoView.java
+++ b/src/main/java/mn.tck.semitone/PianoView.java
@@ -54,7 +54,7 @@ public class PianoView extends View {
     HashMap<Integer, Integer> pointers;
 
     int concert_a;
-    boolean sustain, labelnotes;
+    boolean sustain, labelnotes, labelnoteslight;
 
     public PianoView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -136,7 +136,8 @@ public class PianoView extends View {
                         y + whiteHeight - OUTLINE*2 - YPAD,
                         pressed[p] ? grey4Paint : whitePaint);
 
-                if (labelnotes) canvas.drawText(
+                // label notes if labelnotes is true and either labelnoteslight is "off" or we are at a C note
+                if (labelnotes && (!labelnoteslight || p % 12 == 0)) canvas.drawText(
                         Util.notenames[(p+3)%12] + (p/12 - 1),
                         x + whiteWidth/2, y + whiteHeight*4/5, blackPaint);
 

--- a/src/main/res/drawable/reset_view.xml
+++ b/src/main/res/drawable/reset_view.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>
+</vector>

--- a/src/main/res/layout-land/piano.xml
+++ b/src/main/res/layout-land/piano.xml
@@ -45,7 +45,17 @@
                 android:layout_height="wrap_content"
                 android:src="@drawable/remove_circle_24"
                 android:padding="5dp" />
+            <android.widget.Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
 
+            <ImageView
+                android:id="@+id/reset_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/reset_view"
+                android:padding="5dp" />
         </LinearLayout>
 
         <LinearLayout

--- a/src/main/res/layout-land/piano.xml
+++ b/src/main/res/layout-land/piano.xml
@@ -3,6 +3,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:semitone="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -45,11 +46,25 @@
                 android:layout_height="wrap_content"
                 android:src="@drawable/remove_circle_24"
                 android:padding="5dp" />
+
             <android.widget.Space
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"/>
 
+            <Spinner
+                android:id="@+id/root_note_spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:entries="@array/noteNames"
+                android:spinnerMode="dropdown" />
+
+            <Spinner
+                android:id="@+id/scale_spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:entries="@array/scaleNamesShort"
+                android:spinnerMode="dropdown" />
             <ImageView
                 android:id="@+id/reset_view"
                 android:layout_width="wrap_content"

--- a/src/main/res/layout/activity_main.xml
+++ b/src/main/res/layout/activity_main.xml
@@ -29,7 +29,7 @@
         <!--     android:src="@drawable/fullscreen_24" -->
         <!--     android:padding="5dp" /> -->
 
-        <View android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" />
+        <Space android:layout_width="0dp" android:layout_height="match_parent" android:layout_weight="1" />
 
         <ImageView
             android:id="@+id/settings"

--- a/src/main/res/layout/piano.xml
+++ b/src/main/res/layout/piano.xml
@@ -46,6 +46,17 @@
                 android:src="@drawable/remove_circle_24"
                 android:padding="5dp" />
 
+            <android.widget.Space
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"/>
+
+            <ImageView
+                android:id="@+id/reset_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/reset_view"
+                android:padding="5dp" />
         </LinearLayout>
 
         <LinearLayout

--- a/src/main/res/layout/piano.xml
+++ b/src/main/res/layout/piano.xml
@@ -46,11 +46,22 @@
                 android:src="@drawable/remove_circle_24"
                 android:padding="5dp" />
 
-            <android.widget.Space
-                android:layout_width="0dp"
+            <Spinner
+                android:id="@+id/root_note_spinner"
+                android:layout_width="wrap_content"
+                android:layout_weight="1"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"/>
+                android:layout_gravity="center_vertical"
+                android:entries="@array/noteNames"
+                android:spinnerMode="dropdown" />
 
+            <Spinner
+                android:id="@+id/scale_spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:entries="@array/scaleNames"
+                android:spinnerMode="dropdown" />
             <ImageView
                 android:id="@+id/reset_view"
                 android:layout_width="wrap_content"

--- a/src/main/res/values-es/strings.xml
+++ b/src/main/res/values-es/strings.xml
@@ -20,6 +20,7 @@
 
     <string name="labelnotes_title">Etiquetar notas</string>
     <string name="labelnotes_summary">Mostrar los nombres de las notas en las teclas</string>
+    <string name="labelnoteslight_title">Mostrar etiqueta solo para C</string>
 
     <!-- ABOUT -->
 

--- a/src/main/res/values/colors.xml
+++ b/src/main/res/values/colors.xml
@@ -7,6 +7,9 @@
     <color name="grey3">#585858</color>
     <color name="grey4">#b8b8b8</color>
     <color name="white">#d8d8d8</color>
+
+    <color name="whiteScale">#FFFD8A</color>
+    <color name="blackScale">#615F00</color>
     <!-- <color name="red">#ab4642</color> -->
     <!-- <color name="orange">#dc9656</color> -->
     <!-- <color name="yellow">#f7ca88</color> -->

--- a/src/main/res/values/scales.xml
+++ b/src/main/res/values/scales.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--Scales from python-musthe:-->
+    <!-- ok C major            ['C', 'D', 'E', 'F', 'G', 'A', 'B']-->
+    <!-- ok C natural_minor    ['C', 'D', 'Eb', 'F', 'G', 'Ab', 'Bb']-->
+    <!--C harmonic_minor   ['C', 'D', 'Eb', 'F', 'G', 'Ab', 'B']-->
+    <!--C melodic_minor    ['C', 'D', 'Eb', 'F', 'G', 'A', 'B']-->
+    <!-- ok C major_pentatonic ['C', 'D', 'E', 'G', 'A']-->
+    <!-- ok C minor_pentatonic ['C', 'Eb', 'F', 'G', 'Bb']-->
+
+    <!-- TODO I18N scale names -->
+    <string-array name="scaleNames">
+        <item>None</item>
+        <item>Natural Major</item>
+        <item>Natural Minor</item>
+        <item>Harmonic Minor</item>
+        <item>Melodic Minor</item>
+        <item>Pentatonic Major</item>
+        <item>Pentatonic Minor</item>
+    </string-array>
+    <string-array name="scaleNamesShort">
+        <item>-</item>
+        <item>NatMaj</item>
+        <item>NatMin</item>
+        <item>HarMin</item>
+        <item>MelMin</item>
+        <item>PenMaj</item>
+        <item>PenMin</item>
+    </string-array>
+    <string-array name="noteNames">
+        <item>C</item>
+        <item>C# / Db</item>
+        <item>D</item>
+        <item>D# / Eb</item>
+        <item>E</item>
+        <item>F</item>
+        <item>F# / Gb</item>
+        <item>G</item>
+        <item>G# / Ab</item>
+        <item>A</item>
+        <item>A# / Bb</item>
+        <item>B</item>
+    </string-array>
+    <array name="scales">
+        <item>@array/noscale</item>
+        <item>@array/natural_major</item>
+        <item>@array/natural_minor</item>
+        <item>@array/harmonic_minor</item>
+        <item>@array/melodic_minor</item>
+        <item>@array/pentatonic_major</item>
+        <item>@array/pentatonic_minor</item>
+    </array>
+    <integer-array name="noscale">
+        <item>0</item> <!-- C -->
+        <item>0</item> <!-- C# / Db -->
+        <item>0</item> <!-- D -->
+        <item>0</item> <!-- D# / Eb -->
+        <item>0</item> <!-- E -->
+        <item>0</item> <!-- F -->
+        <item>0</item> <!-- F# / Gb -->
+        <item>0</item> <!-- G -->
+        <item>0</item> <!-- G# / Ab -->
+        <item>0</item> <!-- A -->
+        <item>0</item> <!-- A# / Bb -->
+        <item>0</item> <!-- B -->
+    </integer-array>
+    <integer-array name="natural_major">
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+    <integer-array name="natural_minor">
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+    </integer-array>
+    <integer-array name="harmonic_minor">
+        <item>1</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>1</item>
+        <item>0</item>
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+    <integer-array name="melodic_minor">
+        <item>1</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+    <integer-array name="pentatonic_major">
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>0</item>
+    </integer-array>
+    <integer-array name="pentatonic_minor">
+        <item>1</item>
+        <item>0</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+        <item>0</item>
+        <item>1</item>
+        <item>0</item>
+    </integer-array>
+</resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
 
     <string name="labelnotes_title">Label notes</string>
     <string name="labelnotes_summary">Show note names on piano keys</string>
+    <string name="labelnoteslight_title">Show label for C only</string>
 
     <!-- ABOUT -->
 

--- a/src/main/res/xml/settings.xml
+++ b/src/main/res/xml/settings.xml
@@ -27,7 +27,12 @@
         <CheckBoxPreference
             android:key="labelnotes"
             android:title="@string/labelnotes_title"
-            android:summary="@string/labelnotes_summary" />
+            android:summary="@string/labelnotes_summary"/>
+
+        <CheckBoxPreference
+            android:dependency="labelnotes"
+            android:key="labelnoteslight"
+            android:title="@string/labelnoteslight_title"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Some improvements for the piano view:

* Piano configuration is stored in shared preferences and thus survives restarts and device rotations
* labeling of the keys can be restricted to the C notes only
* user can select a scale and a root note, the keys of the scale will then be highlighted

Can you consider these changes for inclusion in semitone?
Thanks for giving them some thoughts:)

