### PR TITLE
Adjustments to semitone to make it usable as a library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="mn.tck.semitone">
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-sdk android:minSdkVersion="16"
-              android:targetSdkVersion="28" />
     <application android:label="@string/app_name"
                  android:icon="@mipmap/ic_launcher"
                  android:theme="@style/SemitoneTheme"

--- a/src/main/java/mn.tck.semitone/AboutActivity.java
+++ b/src/main/java/mn.tck.semitone/AboutActivity.java
@@ -22,7 +22,8 @@ import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.webkit.WebView;
-import android.support.v7.app.AppCompatActivity;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class AboutActivity extends AppCompatActivity {
 

--- a/src/main/java/mn.tck.semitone/MainActivity.java
+++ b/src/main/java/mn.tck.semitone/MainActivity.java
@@ -27,13 +27,15 @@ import android.view.ViewGroup;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ImageView;
-import android.support.design.widget.TabLayout;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.ViewPager;
-import android.support.v7.preference.PreferenceManager;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.preference.PreferenceManager;
+import androidx.viewpager.widget.ViewPager;
+
+import com.google.android.material.tabs.TabLayout;
 
 public class MainActivity extends FragmentActivity {
 
@@ -136,17 +138,15 @@ public class MainActivity extends FragmentActivity {
 
     @Override public boolean onOptionsItemSelected(MenuItem item) {
         Intent intent;
-        switch (item.getItemId()) {
-        case R.id.menu_settings:
+        if (item.getItemId() == R.id.menu_settings) {
             startActivityForResult(new Intent(this, SettingsActivity.class),
                     SETTINGS_INTENT_CODE);
             return true;
-        case R.id.menu_about:
+        } else if (item.getItemId() == R.id.menu_about) {
             startActivity(new Intent(this, AboutActivity.class));
             return true;
-        default:
+        } else
             return super.onOptionsItemSelected(item);
-        }
     }
 
     private static class SemitoneAdapter extends FragmentPagerAdapter {

--- a/src/main/java/mn.tck.semitone/MetronomeFragment.java
+++ b/src/main/java/mn.tck.semitone/MetronomeFragment.java
@@ -33,7 +33,8 @@ import android.widget.LinearLayout;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.SeekBar;
-import android.support.v4.content.ContextCompat;
+
+import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 

--- a/src/main/java/mn.tck.semitone/PianoEngine.java
+++ b/src/main/java/mn.tck.semitone/PianoEngine.java
@@ -36,7 +36,7 @@ public class PianoEngine {
         System.loadLibrary("semitone-native");
     }
 
-    static boolean create(Context context) {
+    static public boolean create(Context context) {
         if (handle != 0) return true;
         handle = createPianoEngine(context.getAssets());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
@@ -50,7 +50,7 @@ public class PianoEngine {
         return false;
     }
 
-    static void destroy() {
+    public static void destroy() {
         if (handle == 0) return;
         destroyPianoEngine(handle);
         handle = 0;

--- a/src/main/java/mn.tck.semitone/PianoFragment.java
+++ b/src/main/java/mn.tck.semitone/PianoFragment.java
@@ -23,7 +23,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.support.v7.preference.PreferenceManager;
+import androidx.preference.PreferenceManager;
 
 public class PianoFragment extends SemitoneFragment {
 

--- a/src/main/java/mn.tck.semitone/PianoView.java
+++ b/src/main/java/mn.tck.semitone/PianoView.java
@@ -25,27 +25,28 @@ import android.graphics.Paint;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.preference.PreferenceManager;
+
+import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
 
 import java.util.HashMap;
 
 public class PianoView extends View {
 
     public int rows, keys, pitch;
-    int whiteWidth, whiteHeight, blackWidth, blackHeight;
-    Paint whitePaint, grey1Paint, grey3Paint, grey4Paint, blackPaint;
+    protected int whiteWidth, whiteHeight, blackWidth, blackHeight;
+    protected Paint whitePaint, grey1Paint, grey3Paint, grey4Paint, blackPaint;
 
-    final int OUTLINE = 2, YPAD = 20;
+    protected final int OUTLINE = 2, YPAD = 20;
     final int SAMPLE_RATE = 44100;
     final int MAX_TRACKS = 10;
 
-    int[][] pitches;
-    boolean[] pressed;
+    protected int[][] pitches;
+    protected boolean[] pressed;
     HashMap<Integer, Integer> pointers;
 
-    int concert_a;
-    boolean sustain, labelnotes, labelc;
+    protected int concert_a;
+    protected boolean sustain, labelnotes, labelc;
 
     public PianoView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -214,7 +215,7 @@ public class PianoView extends View {
         if (sustain) PianoEngine.stop(pitch);
     }
 
-    private boolean hasBlackLeft(int p) { return p % 12 != 5 && p % 12 != 0; }
-    private boolean hasBlackRight(int p) { return p % 12 != 4 && p % 12 != 11; }
+    protected boolean hasBlackLeft(int p) { return p % 12 != 5 && p % 12 != 0; }
+    protected boolean hasBlackRight(int p) { return p % 12 != 4 && p % 12 != 11; }
 
 }

--- a/src/main/java/mn.tck.semitone/RecordEngine.java
+++ b/src/main/java/mn.tck.semitone/RecordEngine.java
@@ -3,11 +3,12 @@ package mn.tck.semitone;
 import android.Manifest;
 import android.app.Activity;
 import android.content.pm.PackageManager;
-import android.support.v4.content.ContextCompat;
 
 import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.media.MediaRecorder.AudioSource;
+
+import androidx.core.content.ContextCompat;
 
 public class RecordEngine {
 

--- a/src/main/java/mn.tck.semitone/SemitoneFragment.java
+++ b/src/main/java/mn.tck.semitone/SemitoneFragment.java
@@ -18,7 +18,7 @@
 
 package mn.tck.semitone;
 
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 
 public abstract class SemitoneFragment extends Fragment {
     abstract void onSettingsChanged();

--- a/src/main/java/mn.tck.semitone/SettingsActivity.java
+++ b/src/main/java/mn.tck.semitone/SettingsActivity.java
@@ -22,7 +22,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Window;
-import android.support.v7.app.AppCompatActivity;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 public class SettingsActivity extends AppCompatActivity {
 

--- a/src/main/java/mn.tck.semitone/SettingsFragment.java
+++ b/src/main/java/mn.tck.semitone/SettingsFragment.java
@@ -19,7 +19,8 @@
 package mn.tck.semitone;
 
 import android.os.Bundle;
-import android.support.v7.preference.PreferenceFragmentCompat;
+
+import androidx.preference.PreferenceFragmentCompat;
 
 public class SettingsFragment extends PreferenceFragmentCompat {
 

--- a/src/main/java/mn.tck.semitone/TunerFragment.java
+++ b/src/main/java/mn.tck.semitone/TunerFragment.java
@@ -28,7 +28,8 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.widget.TextView;
 import android.util.TypedValue;
-import android.support.v7.preference.PreferenceManager;
+
+import androidx.preference.PreferenceManager;
 
 import java.util.Arrays;
 

--- a/src/main/java/mn.tck.semitone/Util.java
+++ b/src/main/java/mn.tck.semitone/Util.java
@@ -22,7 +22,7 @@ import android.text.TextPaint;
 
 public class Util {
 
-    final static String[] notenames = {"A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#"};
+    public final static String[] notenames = {"A", "A#", "B", "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#"};
 
     public static int maxTextSize(String text, int maxWidth) {
         TextPaint paint = new TextPaint();


### PR DESCRIPTION
I am working on a separate project (https://github.com/sluedecke/tonality) which aims at providing a feature enhanced piano view (scale highlighting as a starter).  Since I don't want to do copy paste and I would love to be able to easily integrate changes from semitone, I am using semitone as a library.  In order to be able to do this, some changes were made:

. switched to androidx.* libraries
. adjusted visibility of certain attributes and methods to enable usage
  from a different package: PianoEngine, PianoFragment,
  MainActivity::onOptionsItemSelected, Util

Can you give them a shot?  They should keep semitone as it is, just make it somewhat more compatible.