### PR TITLE
Add monochrome icon

### DIFF
--- a/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background" />
     <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>


### PR DESCRIPTION
Added monochrome icon for Android 13 "Themed icons" support.

Before:
![SS_20220918_202503](https://user-images.githubusercontent.com/26635624/190920413-a5b9c432-483a-408c-8e29-4a76c30f6cea.png)

After:
![SS_20220918_202543](https://user-images.githubusercontent.com/26635624/190920421-3c5cb306-2cef-46fa-bdfb-39d5d882d446.png)
